### PR TITLE
updated selected-sites container height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -380,7 +380,7 @@ fieldset{
     background-color: #e1c3e725;
     border: 3px solid #f5b8b8af;
     border-radius: 10px;
-    height: 320px;
+    height: 340px;
 }
 
 /* styled the window scrollbar */


### PR DESCRIPTION
there isn't a unnecessary vertical scroll bar on the saved-sites section anymore, only horizontal underneath the websites as intended